### PR TITLE
Print % of Wins, and rename @benchmark for 2 exp

### DIFF
--- a/src/benchmarks.jl
+++ b/src/benchmarks.jl
@@ -67,6 +67,13 @@ function benchmark(f::Function, f2::Function, category::String, name::String, na
     df["CodeHash"] = NA
   end
   df["OS"] = string(OS_NAME)
+
+  
+  println("$name wins to $name2 on the $(N1 > N2 ? mean( times1[1:N2] .< times2 )*100 : mean( times1 .< times2[1:N1] )*100)% of runnings")
+  println("$name2 wins to $name on the $(N1 > N2 ? mean( times1[1:N2] .> times2 )*100 : mean( times1 .> times2[1:N1] )*100)% of runnings")
+  println("Ties: $(N1 > N2 ? mean( times1[1:N2] .== times2 )*100 : mean( times1 .== times2[1:N1] )*100)%")
+  
+
   return df
 end
 
@@ -103,7 +110,7 @@ macro benchmark(ex, category, name, N)
 end
 
 # For comparing two expressions
-macro benchmark(ex, ex2, category, name, name2, N)
+macro benchmark2(ex, ex2, category, name, name2, N)
   df = DataFrame()
   choosed = rand(2N) .<= .5
   N1= sum(choosed)
@@ -145,6 +152,11 @@ macro benchmark(ex, ex2, category, name, name2, N)
     df["CodeHash"] = NA
   end
   df["OS"] = string(OS_NAME)
+  
+  println("$name wins to $name2 on the $(N1 > N2 ? mean( times1[1:N2] .< times2 )*100 : mean( times1 .< times2[1:N1] )*100)% of runnings")
+  println("$name2 wins to $name on the $(N1 > N2 ? mean( times1[1:N2] .> times2 )*100 : mean( times1 .> times2[1:N1] )*100)% of runnings")
+  println("Ties: $(N1 > N2 ? mean( times1[1:N2] .== times2 )*100 : mean( times1 .== times2[1:N1] )*100)%")
+
   return df
 end
 


### PR DESCRIPTION
% of wins on runnings gives and idea of how consistent is the difference. It's useful now. I'm using it and avoids me some bad interpretations. In the future some statistical test can help even more.
The two macros are crashing, I rename one to benchmark2 in order to avoid:

```
julia> @benchmark(quote f() end,quote g() end,"cmp","f","g",100)
WARNING: push is deprecated, use push! instead.
WARNING: push is deprecated, use push! instead.
WARNING: push is deprecated, use push! instead.
WARNING: push is deprecated, use push! instead.
WARNING: push is deprecated, use push! instead.
WARNING: push is deprecated, use push! instead.
WARNING: push is deprecated, use push! instead.
WARNING: push is deprecated, use push! instead.
WARNING: push is deprecated, use push! instead.
WARNING: push is deprecated, use push! instead.
WARNING: push is deprecated, use push! instead.
WARNING: push is deprecated, use push! instead.
WARNING: push is deprecated, use push! instead.
WARNING: push is deprecated, use push! instead.
WARNING: push is deprecated, use push! instead.
WARNING: push is deprecated, use push! instead.
WARNING: push is deprecated, use push! instead.
WARNING: push is deprecated, use push! instead.
WARNING: push is deprecated, use push! instead.
WARNING: push is deprecated, use push! instead.
WARNING: push is deprecated, use push! instead.
WARNING: push is deprecated, use push! instead.
WARNING: push is deprecated, use push! instead.
WARNING: push is deprecated, use push! instead.
f wins to g on the 8.791208791208792% of runnings
g wins to f on the 7.6923076923076925% of runnings
Ties: 83.51648351648352%

2x12 DataFrame:
        BenchmarkCategory BenchmarkName Iterations  TotalWall AverageWall    MaxWall MinWall             Timestamp            JuliaVersion    JuliaHash CodeHash      OS
[1,]                "cmp"           "f"         91 6.91414e-6  7.59795e-8 1.19209e-6     0.0 "2013-01-09 16:25:24" "0.0.0+106748552.r7d5d" "7d5debe4ef"       NA "Linux"
[2,]                "cmp"           "g"        109 8.82149e-6  8.09311e-8 1.19209e-6     0.0 "2013-01-09 16:25:24" "0.0.0+106748552.r7d5d" "7d5debe4ef"       NA "Linux"


julia> @benchmark(quote f() end,"cmp","f",100)
in @benchmark: wrong number of arguments

```

Note there are some push to rename in DataFrames
Best
