### PR TITLE
Passing the same args to the functions

### DIFF
--- a/src/compare.jl
+++ b/src/compare.jl
@@ -1,9 +1,9 @@
-function compare(fs::Vector{Function}, replications::Integer)
+function compare(fs::Vector{Function}, replications::Integer,args...)
 	n = length(fs)
 
 	# Force JIT compilation
 	for i in 1:n
-		fs[i]()
+		fs[i](args...)
 	end
 
 	n_total = replications * n
@@ -13,7 +13,7 @@ function compare(fs::Vector{Function}, replications::Integer)
 
 	times = DataArray(Float64, n_total)
 	for i in 1:n_total
-		times[i] = @elapsed fs[indices[i]]()
+		times[i] = @elapsed fs[indices[i]](args...)
 	end
 
 	df = DataFrame({times, indices}, ["Time", "Function"])


### PR DESCRIPTION
Works fine:

```
julia> using Benchmark

julia> function bitlower()
       'A' | 32
       end

julia> function bl(x)
       x | 32
       end

julia> function intlower()
       'A' + 32
       end

julia> function il(x)
       x + 32
       end

julia> compare
Methods for generic function compare
compare(Array{Function,1},Integer,Any...) at /home/dzea/.julia/Benchmark/src/compare.jl:32

julia> compare([bitlower; intlower],1000)
2x4 DataFrame:
          Function     Elapsed Relative Replications
[1,]    "bitlower" 0.000992537  13.8306         1000
[2,]    "intlower"   7.1764e-5      1.0         1000


julia> compare([bl; il],1000)
no method bl()
 in compare at /home/dzea/.julia/Benchmark/src/compare.jl:36

julia> compare([bl; il],1000,'A')
2x4 DataFrame:
        Function    Elapsed Relative Replications
[1,]        "bl" 7.36713e-5  1.16165         1000
[2,]        "il" 6.34193e-5      1.0         1000

```
