### PR TITLE
compare: allow trailing function varargs

### DIFF
--- a/src/compare.jl
+++ b/src/compare.jl
@@ -27,3 +27,4 @@ function compare(fs::Vector{Function}, replications::Integer)
 
 	return df
 end
+compare(replications::Integer, fs::Function...) = compare(fs, replications)


### PR DESCRIPTION
I consider this a more natural syntax, so I figure I'd throw it out there.
