### PR TITLE
compare: Fix argument type

### DIFF
--- a/src/compare.jl
+++ b/src/compare.jl
@@ -27,4 +27,4 @@ function compare(fs::Vector{Function}, replications::Integer)
 
 	return df
 end
-compare(replications::Integer, fs::Function...) = compare(fs, replications)
+compare(replications::Integer, fs::Function...) = compare([fs...], replications)


### PR DESCRIPTION
There we go. The `...` syntax actually creates a tuple, which doesn't work.
