### PR TITLE
relax `Vector{Function}` to `Vector` in compare

### DIFF
--- a/src/compare.jl
+++ b/src/compare.jl
@@ -1,6 +1,6 @@
 elapsedtime(adf::AbstractDataFrame) = DataFrame(Average = mean(adf[:Time]))
 
-function compare(fs::Vector{Function}, replications::Integer)
+function compare(fs::Vector, replications::Integer)
 	n = length(fs)
 
 	# Force JIT compilation


### PR DESCRIPTION
This is forward-compatible with the function type changes on jb/functions. Makes the package tests pass on my branch.